### PR TITLE
Fix platform and availability mapping in form submission

### DIFF
--- a/src/components/admin/SocialLinksManager.tsx
+++ b/src/components/admin/SocialLinksManager.tsx
@@ -88,9 +88,10 @@ export default function SocialLinksManager() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          ...formData,
-          color: formData.color || '#0088cc',
-          is_active: true // Toujours actif
+          platform: formData.name, // L'API attend 'platform' pas 'name'
+          url: formData.url,
+          icon: formData.icon,
+          is_available: true // L'API attend 'is_available' pas 'is_active'
         }),
       });
 


### PR DESCRIPTION
Correct social link form field mapping to match API expectations, resolving "platform and URL are required" errors.

The previous implementation sent `name` instead of `platform` and `is_active` instead of `is_available`, causing API validation failures and preventing social links from being added or modified.

---
<a href="https://cursor.com/background-agent?bcId=bc-9fb40acd-19cd-4a7a-80fb-c7b7a53c5e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9fb40acd-19cd-4a7a-80fb-c7b7a53c5e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

